### PR TITLE
[plot-tools] Enable to set line width, color, type parameters

### DIFF
--- a/plot-tools.l
+++ b/plot-tools.l
@@ -26,6 +26,7 @@
      &optional (abscissa-list (user::range (length (car ordinate-list))))
      &key (title "Graph") (xlabel "X") (ylabel "Y") (zlabel "Z")
      (dump-graph nil) (graph-fname (format nil "~A.eps" (substitute #\_ (elt " " 0) title)))
+     (lt-lw-params)
      ;;(mode "points")
      (mode "lines")
      keylist xrange yrange zrange
@@ -45,6 +46,7 @@
             (if range (format nil "[~A:~A]" (car range) (cadr range)) "[]"))
            (2d-or-3d (r-2d r-3d) (if (atom (car abscissa-list)) (eval r-2d) (eval r-3d))))
     (unless keylist (setq keylist (user::range (length ordinate-list))))
+    (unless lt-lw-params (setq lt-lw-params (let ((idx -1)) (mapcar #'(lambda (x) (incf idx) "") (make-list (length ordinate-list))))))
     ;; dump dat file
     (unless no-dump
       (with-open-file
@@ -71,7 +73,7 @@
     (if additional-func (funcall additional-func))
     (dotimes (i (length ordinate-list))
       (send gp :command
-            (format nil "~A \"/tmp/~A.dat\" using ~A title \"~A\" with ~A"
+            (format nil "~A \"/tmp/~A.dat\" using ~A title \"~A\" ~A with ~A"
                     (cond
                      ((and (= i 0) (not replot))
                       (apply #'format
@@ -84,6 +86,7 @@
                     fname
                     (format nil "~A:~A" (2d-or-3d "1" "1:2") (+ i (2d-or-3d 2 3)))
                     (elt keylist i)
+                    (elt lt-lw-params i)
                     mode))
       )
     (if x11 (send gp :command "set terminal X11"))


### PR DESCRIPTION
上書き元の`euslib/jsk/gnuplotlib.l`の`graph-view`に加えられた[このcommit](https://github.com/jsk-ros-pkg/euslib/commit/0be7762a7c0106295e1c93014f4e60176d2e5735)の変更を取り込み，プロットの太さや色のパラメータを設定できるように変更しました．

これにより，上書きしているこちらの関数の方は，fork元の変数を全て包含するようになりました．

```
$ documentation 'graph-view # fork元
(ordinate-list &optional (abscissa-list (let ((idx -1)) (mapcar #'(lambda (x) (incf idx)) (make-list (length (car ordinate-list)))))) &key (title "Graph") (xlabel "X") (ylabel "Y") (zlabel "Z") (dump-graph nil) (graph-fname (format nil "~A.eps" (substitute 95 (elt " " 0) title))) (lt-lw-params) (mode "lines") keylist xrange yrange zrange x11 additional-func no-dump ((:graph-instance gp) (if (boundp '*gp*) *gp* (setq *gp* (gnuplot)))) (fname (format nil "data~A" (system:address gp))))
$ documentation 'graph-view # 変更後のこのリポジトリ
(ordinate-list &optional (abscissa-list (range (length (car ordinate-list)))) &key (title "Graph") (xlabel "X") (ylabel "Y") (zlabel "Z") (dump-graph nil) (graph-fname (format nil "~A.eps" (substitute 95 (elt " " 0) title))) (lt-lw-params) (mode "lines") keylist xrange yrange zrange x11 additional-func no-dump ((:graph-instance gp) (if (boundp '*gp*) *gp* (setq *gp* (gnuplot)))) (raw-date (unix:localtime)) (fname (reg-replace* " " "0" (format nil "data_20~2d-~2d-~2d-~2d-~2d-~2d" (- (elt raw-date 5) 100) (+ (elt raw-date 4) 1) (elt raw-date 3) (elt raw-date 2) (elt raw-date 1) (elt raw-date 0)))) (replot nil))
```

(ちなみに，その一つ前の[このcommit](https://github.com/jsk-ros-pkg/euslib/commit/274dc1b9956e622ad9778c76405429742e98b11e)での変更もfork後ですが，動作としては全く同じなので書き換えていません．)