### PR TITLE
[play-hrpsysfile.l] is-choreonoid check by rtls->rosnode

### DIFF
--- a/play-hrpsysfile.l
+++ b/play-hrpsysfile.l
@@ -48,7 +48,7 @@
   (if (ros::get-param "use_sim_time" nil) t nil))
 
 (defun is-choreonoid ()
-  (and (is-simulation) (> (read-from-string (read-line (piped-fork "rtls localhost:15005/ -l |grep HEAD | wc -l"))) 0)))
+  (and (is-simulation) (> (read-from-string (read-line (piped-fork "rosnode list |grep choreonoid | wc -l"))) 0)))
 
 (ros::roseus "play-hrpsysfile.l")
 (ros::load-ros-manifest "trans_ros_bridge")


### PR DESCRIPTION
MANTAのchoreonoidでは，`HEADRIGHT.rtc`や`HEADLEFT.rtc`がないので，`is-choreonoid`がnilになります．
一応，control_toolsのユースケースとして仮定されている [hrpsys_simulator](https://github.com/start-jsk/rtmros_hrp2)や[choreonoid](https://github.com/start-jsk/rtmros_choreonoid)を立ち上げて，正しく機能することを確認しました．

ただ，hrpsys_ros_bridgeが存在することを前提としている(control_toolsを使う時点でその環境を前提としている気もしますが)ので，draftにしています．

現状問題が起きているわけではなく，MANTAで使う場合はlogの名前が変わるぐらいではあります．